### PR TITLE
Removed e-mail requirement in FindByIdAsync

### DIFF
--- a/MySql.AspNet.Identity/MySqlUserStore.cs
+++ b/MySql.AspNet.Identity/MySqlUserStore.cs
@@ -75,7 +75,7 @@ namespace MySql.AspNet.Identity
         public Task<TUser> FindByIdAsync(string userId)
         {
             var user =_userRepository.GetById(userId);
-            if (user != null && !string.IsNullOrEmpty(user.Email))
+            if (user != null)
             {
                 user.Roles = _userRoleRepository.PopulateRoles(user.Id);
                 user.Claims = _userClaimRepository.PopulateClaims(user.Id);


### PR DESCRIPTION
If the record didn't contain an e-mail FindByIdAsync would return null even if there was a record
